### PR TITLE
Add read_quality_check.py to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(name='AmpliconTyper',
           'scripts/map.py',
           'scripts/model_manager.py',
           'scripts/read_classifier.py',
+          'scripts/read_quality_check.py',
           'scripts/reporting_classes.py',
           'scripts/train.py'
       ],


### PR DESCRIPTION
Otherwise ModuleNotFoundError arises when other scripts attempt to import this module.

Fix for failing test in Bioconda update https://github.com/bioconda/bioconda-recipes/pull/61899